### PR TITLE
Use max health for target HUD

### DIFF
--- a/src/main/java/zenith/zov/client/hud/elements/component/TargetHudComponent.java
+++ b/src/main/java/zenith/zov/client/hud/elements/component/TargetHudComponent.java
@@ -76,8 +76,8 @@ public class TargetHudComponent extends DraggableHudElement {
 
 
             float hp = round(PlayerIntersectionUtil.getHealth(target));
-            float maxHp = Math.max(20, hp);
-            float healthPercent = hp / maxHp;
+            float maxHp = target.getMaxHealth();
+            float healthPercent = hp / target.getMaxHealth();
             float barFullWidth = width - padding * 2 - headSize - padding * 2 - 25f; // -25f для HP текста
 
             float animatedHealth = healthAnimation.update(barFullWidth * healthPercent);


### PR DESCRIPTION
## Summary
- compute max health and health bar percentage from target's max health

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c70d081e448323a54a15755b1fe965