### PR TITLE
feat(gui): redesign click menu layout

### DIFF
--- a/src/main/java/zenith/zov/client/screens/menu/panels/SideBarCategory.java
+++ b/src/main/java/zenith/zov/client/screens/menu/panels/SideBarCategory.java
@@ -20,24 +20,40 @@ public class SideBarCategory {
         animationSwitch = new Animation(200, category == Category.COMBAT ? 1 : 0, Easing.LINEAR);
     }
 
-    public void render(UIContext ctx, float x, float y, float width, float height, float sidebarProgress, boolean selected, ColorRGBA textColor,ColorRGBA textColorDisable, ColorRGBA iconColorDisable, ColorRGBA primary) {
+    public void render(UIContext ctx,
+                       float x,
+                       float y,
+                       float width,
+                       float height,
+                       float sidebarProgress,
+                       boolean selected,
+                       ColorRGBA textColor,
+                       ColorRGBA textColorDisable,
+                       ColorRGBA iconColorDisable,
+                       ColorRGBA primary) {
         animationSwitch.animateTo(selected ? 1 : 0);
         animationSwitch.update();
-        ColorRGBA mixColor = iconColorDisable.mix(primary, animationSwitch.getValue());
-        ColorRGBA mixColorText = textColorDisable.mix(textColor, animationSwitch.getValue());
-        Font font = Fonts.ICONS.getFont(7);
 
-        float offestY = (height - font.height()) / 2;
-        float scale = MathHelper.lerp(sidebarProgress,1f,0.8f);
-        float iconWidth = font.width(category.getIcon());
+        Font iconFont = Fonts.ICONS.getFont(7);
+        Font labelFont = Fonts.MEDIUM.getFont(6.5f);
+
+        float iconX = x + 12f;
+        float iconY = y + (height - iconFont.height()) / 2f;
+        float iconScale = MathHelper.lerp(sidebarProgress, 0.85f, 1f);
+
+        ColorRGBA iconColor = iconColorDisable.mix(primary, animationSwitch.getValue());
+
         ctx.pushMatrix();
-        ctx.getMatrices().translate(x + 8 + iconWidth/2 +(category==Category.PLAYER?1:0), y + offestY+font.height()/2,0);
-        ctx.getMatrices().scale(scale,scale,1);
-        ctx.getMatrices().translate(-(x + 8 + iconWidth/2), -(y + offestY+font.height()/2),0);
-        ctx.drawText(Fonts.ICONS.getFont(7), category.getIcon(), x + 8, y + offestY, mixColor);
+        ctx.getMatrices().translate(iconX + iconFont.width(category.getIcon()) / 2f, iconY + iconFont.height() / 2f, 0);
+        ctx.getMatrices().scale(iconScale, iconScale, 1);
+        ctx.getMatrices().translate(-(iconX + iconFont.width(category.getIcon()) / 2f), -(iconY + iconFont.height() / 2f), 0);
+        ctx.drawText(iconFont, category.getIcon(), iconX, iconY, iconColor.mulAlpha(MathHelper.clamp(sidebarProgress, 0.35f, 1f)));
         ctx.popMatrix();
-        Font categoryFont = Fonts.MEDIUM.getFont(7);
-        ctx.drawText(categoryFont,category.getName(),x + 8+iconWidth*scale+6,y+(height-font.height())/2,mixColorText);
+
+        float textX = iconX + iconFont.width(category.getIcon()) * iconScale + 8f;
+        float textY = y + (height - labelFont.height()) / 2f;
+        ColorRGBA blended = textColorDisable.mix(textColor, animationSwitch.getValue());
+        ctx.drawText(labelFont, category.getName(), textX, textY, blended.mulAlpha(MathHelper.clamp(sidebarProgress, 0f, 1f)));
     }
 
 }

--- a/src/main/java/zenith/zov/client/screens/menu/panels/SidebarPanel.java
+++ b/src/main/java/zenith/zov/client/screens/menu/panels/SidebarPanel.java
@@ -1,8 +1,7 @@
 package zenith.zov.client.screens.menu.panels;
 
-import by.saskkeee.user.UserInfo;
 import lombok.Getter;
-import zenith.zov.Zenith;
+import net.minecraft.util.math.MathHelper;
 import zenith.zov.base.animations.base.Animation;
 import zenith.zov.base.animations.base.Easing;
 import zenith.zov.base.font.Font;
@@ -10,11 +9,17 @@ import zenith.zov.base.font.Fonts;
 import zenith.zov.base.theme.Theme;
 import zenith.zov.client.modules.api.Category;
 import zenith.zov.utility.math.MathUtil;
-import zenith.zov.utility.render.display.base.*;
+import zenith.zov.utility.render.display.base.BorderRadius;
+import zenith.zov.utility.render.display.base.Rect;
+import zenith.zov.utility.render.display.base.UIContext;
 import zenith.zov.utility.render.display.base.color.ColorRGBA;
 import zenith.zov.utility.render.display.shader.DrawUtil;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 public class SidebarPanel {
@@ -24,136 +29,86 @@ public class SidebarPanel {
     @Getter
     private Rect sidebarToggleButtonBounds;
     private Rect animRect = new Rect(0, 0, 0, 0);
-    private Animation animationChange = new Animation(200, 1, Easing.LINEAR);
+    private final Animation animationChange = new Animation(200, 1, Easing.LINEAR);
     private final Animation sidebarAnimation;
-    private final boolean isSidebarExpanded;
 
     private final Consumer<Category> onCategorySelect;
     private final Runnable onSidebarToggle;
     private final List<SideBarCategory> categories = new ArrayList<>();
 
-    public SidebarPanel(Animation sidebarAnimation, boolean isSidebarExpanded, Consumer<Category> onCategorySelect, Runnable onSidebarToggle) {
+    public SidebarPanel(Animation sidebarAnimation,
+                        boolean isSidebarExpanded,
+                        Consumer<Category> onCategorySelect,
+                        Runnable onSidebarToggle) {
         this.sidebarAnimation = sidebarAnimation;
-        this.isSidebarExpanded = isSidebarExpanded;
         this.onCategorySelect = onCategorySelect;
         this.onSidebarToggle = onSidebarToggle;
+        this.sidebarAnimation.setValue(isSidebarExpanded ? 1f : 0f);
         categories.addAll(Arrays.stream(Category.values()).map(SideBarCategory::new).toList());
-
     }
 
-    public void render(UIContext ctx, float boxX, float boxY, float height, float progress, Theme theme, Category selectedCategory, ColorRGBA primary, ColorRGBA textColor, ColorRGBA selectedColor) {
-        float sidebarProgress = sidebarAnimation.update();
-        float collapsedSidebarWidth = 30f;
-        float expandedSidebarWidth = 88;
-        float sidebarWidth = collapsedSidebarWidth + (expandedSidebarWidth - collapsedSidebarWidth) * sidebarProgress;
-        float sidebarPadding = 8;
-        float sidebarX = boxX + sidebarPadding;
-        float sidebarY = boxY + sidebarPadding;
-        float sidebarHeight =height - sidebarPadding * 2;
-        ColorRGBA sideBar = theme.getForegroundColor().mulAlpha(progress);
+    public void render(UIContext ctx,
+                       float startX,
+                       float startY,
+                       float width,
+                       float height,
+                       float progress,
+                       Theme theme,
+                       Category selectedCategory,
+                       ColorRGBA accentColor,
+                       ColorRGBA textColor,
+                       ColorRGBA selectedTextColor) {
 
         categoryBounds.clear();
 
-        // --- СЛАЙДБАР ---
-        ctx.drawRoundedRect(sidebarX, sidebarY, sidebarWidth, sidebarHeight, BorderRadius.all(7), sideBar);
-        DrawUtil.drawRoundedBorder(
-                ctx.getMatrices(),
-                sidebarX, sidebarY,
-                sidebarWidth, sidebarHeight,
-                -0.1f,
-                BorderRadius.all(7),
-                theme.getForegroundStroke().mulAlpha(progress)
-        );
+        float expandProgress = sidebarAnimation.update();
+        float toggleSize = height;
+        float toggleRadius = height / 2f;
 
-        // --- ИКОНКИ ---
-        float logoSize = 14;
-        float logoX = sidebarX + (collapsedSidebarWidth - logoSize) / 2f;
-        float logoY = sidebarY + 8;
-        ctx.drawText(Fonts.ICONS.getFont(11), "5", logoX + 2, logoY + 3, Zenith.getInstance().getThemeManager().getColorCycleIcon().toGradient().mulAlpha(progress));
+        ColorRGBA toggleColor = theme.getForegroundColor().mulAlpha(progress * 0.75f);
+        ctx.drawRoundedRect(startX, startY, toggleSize, height, BorderRadius.all(toggleRadius), toggleColor);
+        DrawUtil.drawRoundedBorder(ctx.getMatrices(), startX, startY, toggleSize, height, -0.1f, BorderRadius.all(toggleRadius), theme.getForegroundStroke().mulAlpha(progress * 0.6f));
 
+        Font toggleFont = Fonts.MEDIUM.getFont(7);
+        String toggleIcon = expandProgress > 0.5f ? "<" : ">";
+        float toggleIconX = startX + (toggleSize - toggleFont.width(toggleIcon)) / 2f;
+        float toggleIconY = startY + (height - toggleFont.height()) / 2f;
+        ctx.drawText(toggleFont, toggleIcon, toggleIconX, toggleIconY, textColor.mulAlpha(progress));
+        sidebarToggleButtonBounds = new Rect(startX, startY, toggleSize, height);
 
-        //ctx.drawSprite(new CustomSprite("icons/logo.png"), logoX, logoY, logoSize, logoSize, primary);
-        ctx.pushMatrix();
-        ctx.enableScissor((int) sidebarX, (int) sidebarY,
-                (int) (sidebarX + sidebarWidth), (int) (sidebarY + sidebarHeight));
-        float textAlpha = Math.min(1f, sidebarProgress * 2f);
-        textColor = textColor.mulAlpha(textAlpha);
-        ColorRGBA textColorDisable = theme.getGrayLight().mulAlpha(progress * textAlpha);
-        ColorRGBA iconColorDisable = theme.getGray().mulAlpha(progress);
-        {
-            Font logoFont = Fonts.MEDIUM.getFont(7);
-            String clientName = "zenithdlc.net";
+        float chipX = startX + toggleSize + 12f;
+        float gap = 8f;
 
-            ctx.drawText(logoFont, clientName, logoX + logoSize + 8, logoY + (logoSize - logoFont.height()) / 2f + 1, textColor);
-        }
+        Font labelFont = Fonts.MEDIUM.getFont(6.5f);
 
-        final float expandedIconSize = 10f;
-        final float collapsedIconSize = 7f;
-
-        float iconSize = expandedIconSize + (collapsedIconSize - expandedIconSize) * sidebarProgress;
-        float padding = 10.5f;
-        float startY = sidebarY + 35;
-
-
-        {
-            //render border+back active category
-            int index = 0;
-            for (SideBarCategory sideBarCategory : categories) {
-                if (selectedCategory == sideBarCategory.getCategory()) {
-                    float categoryY = startY + index * (iconSize + padding);
-                    float iconX = sidebarX + (collapsedSidebarWidth - iconSize) / 2f;
-                    animRect = new Rect(MathUtil.interpolate(animRect.x(),sidebarX + 4,animationChange.getValue()), MathUtil.interpolate(animRect.y(),categoryY,animationChange.getValue()),sidebarWidth - 8, iconSize + 11);
-                    sideBarCategory.render(ctx, animRect.x(), animRect.y(), sidebarWidth - 8, iconSize + 11, sidebarProgress, selectedCategory == sideBarCategory.getCategory(), textColor, textColorDisable, iconColorDisable, primary);
-                    ctx.drawRoundedRect( animRect.x(), animRect.y(), sidebarWidth - 8, iconSize + 11, BorderRadius.all(4), theme.getForegroundLight().mulAlpha(progress));
-
-                    DrawUtil.drawRoundedBorder(
-                            ctx.getMatrices(),
-                            animRect.x(), animRect.y(), sidebarWidth - 8, iconSize + 11,
-                            -0.1f,
-                            BorderRadius.all(4),
-                            theme.getForegroundLightStroke().mulAlpha(progress)
-                    );
-                    break;
-                }
-                index++;
-            }
-        }
         animationChange.animateTo(1f);
-        animationChange.update();
-        int index = 0;
+        float animationValue = animationChange.update();
+
         for (SideBarCategory sideBarCategory : categories) {
-            float categoryY = startY + index * (iconSize + padding);
-            float iconX = sidebarX + (collapsedSidebarWidth - iconSize) / 2f;
-            sideBarCategory.render(ctx, sidebarX + 4, categoryY, sidebarWidth - 8, iconSize + 11, sidebarProgress, selectedCategory == sideBarCategory.getCategory(), textColor, textColorDisable, iconColorDisable, primary);
-            categoryBounds.put(sideBarCategory.getCategory(), new Rect(sidebarX + 4, categoryY, sidebarWidth - 8, iconSize + 11));
-            index++;
+            Category category = sideBarCategory.getCategory();
+            float textWidth = labelFont.width(category.getName());
+            float chipWidth = MathHelper.lerp(expandProgress, height, height + 18f + textWidth);
+            float chipRadius = 12f;
+
+            if (category == selectedCategory) {
+                float targetX = chipX;
+                float targetWidth = chipWidth;
+                float targetHeight = height;
+                float highlightX = MathUtil.interpolate(animRect.x(), targetX, animationValue);
+                float highlightY = MathUtil.interpolate(animRect.y(), startY, animationValue);
+                float highlightWidth = MathUtil.interpolate(animRect.width(), targetWidth, animationValue);
+                float highlightHeight = MathUtil.interpolate(animRect.height(), targetHeight, animationValue);
+                animRect = new Rect(highlightX, highlightY, highlightWidth, highlightHeight);
+
+                ColorRGBA highlight = theme.getForegroundColor().mix(accentColor, 0.25f).mulAlpha(progress * 0.85f);
+                ctx.drawRoundedRect(animRect.x(), animRect.y(), animRect.width(), animRect.height(), BorderRadius.all(chipRadius), highlight);
+                DrawUtil.drawRoundedBorder(ctx.getMatrices(), animRect.x(), animRect.y(), animRect.width(), animRect.height(), -0.1f, BorderRadius.all(chipRadius), theme.getForegroundStroke().mulAlpha(progress * 0.6f));
+            }
+
+            sideBarCategory.render(ctx, chipX, startY, chipWidth, height, expandProgress, category == selectedCategory, selectedTextColor, textColor.mulAlpha(0.55f), theme.getGray().mulAlpha(progress * 0.6f), accentColor);
+            categoryBounds.put(category, new Rect(chipX, startY, chipWidth, height));
+            chipX += chipWidth + gap;
         }
-
-        // --- АВАТАР И КНОПКА СВОРАЧИВАНИЯ ---
-        float avatarSize = 18;
-        float avatarX = sidebarX + (collapsedSidebarWidth - avatarSize) / 2f;
-        float avatarY = sidebarY + sidebarHeight - avatarSize - 8;
-        float toggleX = avatarX + 5;
-        float toggleY = avatarY - 19;
-        float toggleW = 8;
-        float toggleH = 8;
-
-        Font iconFont = Fonts.ICONS.getFont(7);
-        ctx.drawText(iconFont,"6",toggleX, toggleY,theme.getGray().mulAlpha(progress));
-        sidebarToggleButtonBounds = new Rect(toggleX, toggleY, toggleW, toggleH);
-
-        boolean hover = GuiUtil.isHovered(avatarX, avatarY, avatarSize, avatarSize, ctx);
-
-        DrawUtil.drawRoundedTexture(ctx.getMatrices(), Zenith.id("icons/avatar.png"), avatarX, avatarY, avatarSize, avatarSize, BorderRadius.all(4), ColorRGBA.WHITE.mulAlpha(progress));
-        DrawUtil.drawRoundedBorder(ctx.getMatrices(), avatarX, avatarY, avatarSize, avatarSize, -0.1f, BorderRadius.all(3), new ColorRGBA(181, 162, 255, hover ? 200 : 190).mulAlpha(progress));
-
-        {
-            String playerName = UserInfo.getUsername();
-            Font nameFont = Fonts.MEDIUM.getFont(6);
-            ctx.drawText(nameFont, playerName, avatarX + avatarSize + 8, avatarY + (avatarSize - nameFont.height()) / 2f, textColor);
-        }
-        ctx.disableScissor();
-        ctx.popMatrix();
     }
 
     public boolean handleMouseClicked(double mouseX, double mouseY) {
@@ -166,7 +121,6 @@ public class SidebarPanel {
             if (entry.getValue().contains(mouseX, mouseY)) {
                 animationChange.animateTo(0);
                 animationChange.setValue(0);
-
                 onCategorySelect.accept(entry.getKey());
                 return true;
             }


### PR DESCRIPTION
## Summary
- rebuild the click GUI container with a new hero header, horizontal navigation and refreshed scroll area
- restyle the header panel with animated category title, player card, theme toggle and search pill
- replace the sidebar list with chip-based category pills driven by the existing theme and toggle animations

## Testing
- ./gradlew build *(fails: TargetHudComponent compile errors in existing sources)*

------
https://chatgpt.com/codex/tasks/task_e_68d125186b408323add53d0374d0bc6c