### PR TITLE
refactor(gui): rebuild click menu to card layout

### DIFF
--- a/src/main/java/zenith/zov/client/screens/menu/MenuScreen.java
+++ b/src/main/java/zenith/zov/client/screens/menu/MenuScreen.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.util.math.Vector2f;
 import net.minecraft.util.math.MathHelper;
 import org.lwjgl.glfw.GLFW;
 import zenith.zov.Zenith;
@@ -13,136 +12,126 @@ import zenith.zov.base.animations.base.Easing;
 import zenith.zov.base.font.Font;
 import zenith.zov.base.font.Fonts;
 import zenith.zov.base.theme.Theme;
+import zenith.zov.client.modules.api.Category;
 import zenith.zov.client.modules.impl.render.Interface;
 import zenith.zov.client.screens.menu.elements.api.AbstractMenuElement;
 import zenith.zov.client.screens.menu.elements.impl.MenuModuleElement;
 import zenith.zov.client.screens.menu.elements.impl.MenuThemeElement;
 import zenith.zov.client.screens.menu.panels.HeaderPanel;
-import zenith.zov.client.modules.api.Category;
 import zenith.zov.client.screens.menu.panels.SidebarPanel;
 import zenith.zov.client.screens.menu.settings.api.MenuPopupSetting;
-import zenith.zov.utility.render.display.ScrollHandler;
-import zenith.zov.utility.game.other.render.CustomScreen;
 import zenith.zov.utility.game.other.MouseButton;
+import zenith.zov.utility.game.other.render.CustomScreen;
 import zenith.zov.utility.math.MathUtil;
-import zenith.zov.utility.render.display.TextBox;
+import zenith.zov.utility.render.display.ScrollHandler;
 import zenith.zov.utility.render.display.base.BorderRadius;
 import zenith.zov.utility.render.display.base.UIContext;
 import zenith.zov.utility.render.display.base.color.ColorRGBA;
 import zenith.zov.utility.render.display.shader.DrawUtil;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class MenuScreen extends CustomScreen {
 
     private Category selectedCategory = Category.COMBAT;
-    private Category realSelectedCategory = Category.COMBAT;
-    private float boxX, boxY;
-    @Getter
-    @Setter
-    private int columns = 1;
-    private float boxWidth = 522;
-    private float boxHeight = 316;
 
-    private boolean dragging;
-    private float dragOffsetX, dragOffsetY;
+    private float boxX;
+    private float boxY;
+    private float boxWidth = 560f;
+    private float boxHeight = 360f;
 
-    private final Animation sidebarAnimation = new Animation(300, 0f, Easing.CUBIC_IN_OUT);
-    private boolean isSidebarExpanded;
+    private final float headerHeight = 74f;
+    private final float navHeight = 34f;
+    private final float navSpacing = 18f;
+    private final float outerPadding = 28f;
+    private final float innerPadding = 20f;
+    private final float columnSpacing = 16f;
 
-    private final Animation animationClose = new Animation(300, 0f, Easing.BAKEK_SIZE);
+    private float contentStartX;
+    private float contentY;
+    private float contentWidth;
+    private float visibleContentHeight;
+    private float scrollThumbHeight;
+    private float scrollThumbY;
+
     private boolean initialized;
+    private boolean draggingWindow;
+    private boolean draggingScrollbar;
+    private float dragOffsetX;
+    private float dragOffsetY;
+    private float scrollClickOffset;
 
-    private TextBox searchField;
+    private final Animation animationClose = new Animation(280, 0f, Easing.BAKEK_SIZE);
+    private final Animation animationScrollHeight = new Animation(160, 1f, Easing.QUAD_IN_OUT);
 
     private final ScrollHandler scrollHandler = new ScrollHandler();
+
+    private HeaderPanel headerPanel;
+    private SidebarPanel sidebarPanel;
+
+    private final Set<MenuPopupSetting> popupSettings = new HashSet<>();
+    private final List<AbstractMenuElement> modules = new ArrayList<>();
+
+    private int scaledScissorX;
+    private int scaledScissorY;
+    private int scaledScissorEndX;
+    private int scaledScissorEndY;
 
     @Getter
     @Setter
     private boolean closing = false;
-    private SidebarPanel sidebarPanel;
-    private HeaderPanel headerPanel;
-
-    private int scaledScissorX = 0;
-    private int scaledScissorY = 0;
-    private int scaledScissorEndX = 2000;
-    private int scaledScissorEndY = 2000;
-
-    private final Animation animationColums;
-    private final Animation animationScrollHeight;
-    private final Animation animationChangeCategory;
-    private boolean draggingScrollbar = false;
-    private float scrollClickOffset = 0;
-
-    private Set<MenuPopupSetting> popupSettings = new HashSet<>();
-    List<AbstractMenuElement> modules = new ArrayList<>();
 
     public MenuScreen() {
-        animationColums = new Animation(300, columns == 3 ? 1 : 0, Easing.CUBIC_IN_OUT);
-        animationChangeCategory = new Animation(150, 1, Easing.CUBIC_IN_OUT);
-        animationScrollHeight = new Animation(150, 1, Easing.QUAD_IN_OUT);
+        initialize();
     }
 
     public void initialize() {
-        modules.addAll(Zenith.getInstance().getModuleManager().getModules().stream().map(MenuModuleElement::new).toList());
+        if (!modules.isEmpty()) {
+            return;
+        }
+
+        Zenith.getInstance().getModuleManager().getModules()
+                .stream()
+                .map(MenuModuleElement::new)
+                .forEach(modules::add);
+
         modules.add(new MenuThemeElement(Theme.DARK));
         modules.add(new MenuThemeElement(Theme.LIGHT));
         modules.add(new MenuThemeElement(Theme.CUSTOM_THEME));
-
     }
 
     @Override
     protected void init() {
         closing = false;
-        animationColums.setValue(columns == 3 ? 1 : 0);
-
-        boxWidth = MathHelper.lerp(animationColums.getValue(), 461 + 4, 525 + 8);
-
-        boxHeight = MathHelper.lerp(animationColums.getValue(), 282, 320);
 
         boxX = (this.width - boxWidth) / 2f;
         boxY = (this.height - boxHeight) / 2f;
+
         animationClose.setValue(0f);
         animationClose.update(1f);
+
         if (!initialized) {
-            this.searchField = new TextBox(new Vector2f(boxX + boxWidth - 128 - 8, boxY + 8), Fonts.MEDIUM.getFont(7), "Search", 100);
-            this.sidebarPanel = new SidebarPanel(
-                    this.sidebarAnimation,
-                    this.isSidebarExpanded,
-                    category -> {
+            sidebarPanel = new SidebarPanel(category -> {
+                selectedCategory = category;
+                scrollHandler.setTargetValue(0f);
+            });
 
-                        this.headerPanel.resetAnim(realSelectedCategory, category);
-                        realSelectedCategory = category;
-
-                        this.scrollHandler.setTargetValue(0.0F);
-                        this.searchField.setSelectAll(true);
-                        this.searchField.setSelected(true);
-                        this.searchField.keyPressed(GLFW.GLFW_KEY_BACKSPACE, 0, 0);
-                        this.searchField.setSelected(false);
-                    },
-                    () -> {
-                        this.isSidebarExpanded = !this.isSidebarExpanded;
-                        this.sidebarAnimation.animateTo(this.isSidebarExpanded ? 1f : 0f);
-                    }
-            );
-
-            this.headerPanel = new HeaderPanel(
-                    this.searchField,
-                    () -> this.columns = (this.columns % 3) + 1,
-                    () -> Zenith.getInstance().getThemeManager().switchTheme()
-            );
+            headerPanel = new HeaderPanel(() -> Zenith.getInstance().getThemeManager().switchTheme());
         }
+
         initialized = true;
-
-
     }
 
     @Override
     public void tick() {
-
-        if (closing && animationClose.getValue() == 0.0F) {
-            this.close();
+        if (closing && animationClose.getValue() == 0f) {
+            close();
         }
+
         super.tick();
     }
 
@@ -154,7 +143,7 @@ public class MenuScreen extends CustomScreen {
 
     @Override
     public void renderBackground(DrawContext context, int mouseX, int mouseY, float delta) {
-        //  super.renderBackground(context, mouseX, mouseY, delta);
+        // disable vanilla blur, handled manually
     }
 
     public boolean isFinish() {
@@ -162,115 +151,165 @@ public class MenuScreen extends CustomScreen {
     }
 
     public void renderTop(UIContext ctx, float mouseX, float mouseY) {
-        if (!initialized) return;
+        if (!initialized) {
+            return;
+        }
 
-        animationColums.update(columns == 3 ? 1 : 0);
+        float progress = MathHelper.clamp(animationClose.update(closing ? 0.0F : 1.0F), 0f, 1f);
+        float scale = 0.9f + 0.1f * progress;
 
-        boxWidth = MathHelper.lerp(animationColums.getValue(), 461 + 4, 525 + 8);
-
-        boxHeight = MathHelper.lerp(animationColums.getValue(), 282, 320);
-
-        float progress = animationClose.update(closing ? 0.0F : 1.0F);
-
-        progress = Math.min(Math.max(progress, 0), 1);
-        float sidebarProgress = sidebarAnimation.update();
-        float scale = 0.85f + 0.15f * progress;
         Theme theme = Zenith.getInstance().getThemeManager().getCurrentTheme();
-        MatrixStack ms = ctx.getMatrices();
+        MatrixStack matrices = ctx.getMatrices();
 
         ctx.pushMatrix();
 
-        float scaleX = boxX + boxWidth / 2f;
-        float scaleY = boxY + boxHeight / 2f;
+        float scaleCenterX = boxX + boxWidth / 2f;
+        float scaleCenterY = boxY + boxHeight / 2f;
 
-        ms.translate(scaleX, scaleY, 1);
-        ms.scale(scale, scale, 1);
-        ms.translate(-scaleX, -scaleY, 1);
+        matrices.translate(scaleCenterX, scaleCenterY, 0);
+        matrices.scale(scale, scale, 1f);
+        matrices.translate(-scaleCenterX, -scaleCenterY, 0);
 
-        ColorRGBA primary = theme.getColor().mulAlpha(progress);
-        ColorRGBA baseBg = theme.getBackgroundColor().mulAlpha(progress * 4); // Фон всей гуишки
-        ColorRGBA selectedColor = theme.getWhite().mulAlpha(progress); // Цвет выбранного элемента и текста
-        ColorRGBA textColor = theme.getWhite().mulAlpha(progress); // Цвет обычного текста
+        ColorRGBA surfaceColor = theme.getForegroundDark().mix(theme.getBackgroundColor(), 0.35f).mulAlpha(progress);
+        ColorRGBA outlineColor = theme.getForegroundStroke().mulAlpha(progress * 0.6f);
+        ColorRGBA accent = theme.getColor().mulAlpha(progress);
+        ColorRGBA textPrimary = theme.getWhite().mulAlpha(progress);
+        ColorRGBA textSecondary = theme.getGrayLight().mulAlpha(progress * 0.8f);
 
-        // ФОН
-        if (Interface.INSTANCE.isBlur() ) {
-            DrawUtil.drawBlur(ctx.getMatrices(), boxX, boxY, boxWidth, boxHeight, 20 * progress * progress, BorderRadius.all(9), ColorRGBA.WHITE.mulAlpha(progress*2));
+        if (Interface.INSTANCE.isBlur()) {
+            DrawUtil.drawBlur(ctx.getMatrices(), boxX, boxY, boxWidth, boxHeight, 24f * progress * progress,
+                    BorderRadius.all(20f), ColorRGBA.WHITE.mulAlpha(progress * 1.6f));
         }
-        ctx.drawRoundedRect(boxX, boxY, boxWidth, boxHeight, BorderRadius.all(9), baseBg);
-        float widthScroll = 2;
-        // СЛАЙДБАР
-        sidebarPanel.render(ctx, boxX, boxY, boxHeight, progress, theme, realSelectedCategory, primary, textColor, selectedColor);
 
-        //НАХОЖДЕНИЕ
-        float sidebarWidth = 30f + (88f - 30f) * sidebarProgress;
-        float contentStartX = boxX + 8f + sidebarWidth + 8f;
-        float sidebarY = boxY + 8f;
-        float contentY = boxY + 22f + 8f + 8f;
+        ctx.drawRoundedRect(boxX, boxY, boxWidth, boxHeight, BorderRadius.all(20f), surfaceColor);
+        DrawUtil.drawRoundedBorder(ctx.getMatrices(), boxX, boxY, boxWidth, boxHeight, -0.1f,
+                BorderRadius.all(20f), outlineColor);
 
-        headerPanel.render(ctx, contentStartX, sidebarY, boxX, columns, boxWidth, progress, theme, realSelectedCategory);
-        //рендер скролла
-        float visibleHeight = boxHeight - (22f + 8f + 8f + 8f);
-        float scrollProgress = scrollHandler.getMax() == 0 ? 0f : (float) (scrollHandler.getValue() / scrollHandler.getMax());
-        float scrollHeight = Math.max(visibleHeight * (visibleHeight / (float) (visibleHeight + scrollHandler.getMax())), 20);
-        scrollHeight = Math.min(visibleHeight, animationScrollHeight.update(scrollHeight));
-        float denom = Math.max(1f, (visibleHeight - scrollHeight));
-        float scrollY = contentY +denom * scrollProgress;
-        scrollY = Math.min(contentY + visibleHeight, scrollY);
-        ctx.drawRoundedRect(boxX + boxWidth - 8 - widthScroll, contentY, widthScroll, visibleHeight, BorderRadius.all(0.5f), theme.getForegroundColor().mulAlpha(progress));
-        if(scrollY+scrollHeight>visibleHeight+contentY) {
-            ctx.drawRoundedRect(boxX + boxWidth - 8 - widthScroll, contentY, widthScroll, (visibleHeight), BorderRadius.all(1f), theme.getForegroundStroke().mulAlpha(progress));
+        float headerY = boxY;
+        ctx.drawRoundedRect(boxX, headerY, boxWidth, headerHeight,
+                BorderRadius.top(20f, 20f), theme.getForegroundColor().mulAlpha(progress * 0.8f));
 
-        }else ctx.drawRoundedRect(boxX + boxWidth - 8 - widthScroll, scrollY, widthScroll, (scrollHeight), BorderRadius.all(1f), theme.getForegroundStroke().mulAlpha(progress));
+        headerPanel.render(ctx, boxX, headerY, boxWidth, headerHeight, progress, theme, selectedCategory, textPrimary, textSecondary);
 
+        float navX = boxX + outerPadding;
+        float navWidth = boxWidth - outerPadding * 2f;
+        float navY = headerY + headerHeight - 16f;
 
-        //Рендер модулей
-        float contentWidth = boxX + (columns == 3 ? 530 : 461) - contentStartX - 8f;
+        float navAreaHeight = sidebarPanel.render(ctx, navX, navY, navWidth, navHeight, progress, theme, selectedCategory, accent,
+                textPrimary, textSecondary.mulAlpha(0.7f));
 
+        float containerX = navX;
+        float containerY = navY + navAreaHeight + navSpacing;
+        float containerWidth = navWidth;
+        float containerHeight = boxHeight - (containerY - boxY) - outerPadding;
 
-        this.scaledScissorX = (int) contentStartX;
-        this.scaledScissorY = (int) ((int) boxY + (22f + 8f + 8f));
-        this.scaledScissorEndX = (int) (boxX + boxWidth);
-        this.scaledScissorEndY = (int) ((int) boxY + boxHeight);
+        ColorRGBA containerColor = theme.getForegroundColor().mulAlpha(progress * 0.45f);
+        ctx.drawRoundedRect(containerX, containerY, containerWidth, containerHeight, BorderRadius.all(18f), containerColor);
+        DrawUtil.drawRoundedBorder(ctx.getMatrices(), containerX, containerY, containerWidth, containerHeight, -0.1f,
+                BorderRadius.all(18f), outlineColor.mulAlpha(0.75f));
 
-        //-ScissorUtility.startScissor(scaledScissorX, scaledScissorY, scaledScissorWidth, scaledScissorHeight);
+        contentStartX = containerX + innerPadding;
+        contentWidth = containerWidth - innerPadding * 2f;
+        contentY = containerY + innerPadding;
+        visibleContentHeight = containerHeight - innerPadding * 2f;
+        visibleContentHeight = Math.max(120f, visibleContentHeight);
 
-        ctx.enableScissor(this.scaledScissorX, this.scaledScissorY, this.scaledScissorEndX, this.scaledScissorEndY);
-        animationChangeCategory.setEasing(Easing.QUAD_IN_OUT);
+        scaledScissorX = (int) contentStartX;
+        scaledScissorY = (int) contentY;
+        scaledScissorEndX = (int) (contentStartX + contentWidth);
+        scaledScissorEndY = (int) (contentY + visibleContentHeight);
 
-        renderModules(ctx, mouseX, mouseY, progress * animationChangeCategory.update(selectedCategory == realSelectedCategory ? 1 : 0), (int) contentStartX, contentWidth, (int) contentY);
+        ctx.enableScissor(scaledScissorX, scaledScissorY, scaledScissorEndX, scaledScissorEndY);
+        renderModules(ctx, mouseX, mouseY, progress);
         ctx.disableScissor();
-        List<MenuPopupSetting> removes = new ArrayList<>();
-        for (MenuPopupSetting setting : popupSettings) {
 
+        float scrollbarWidth = 4f;
+        float trackX = contentStartX + contentWidth - scrollbarWidth;
+        float trackY = contentY;
+
+        float visibleHeight = visibleContentHeight;
+        float maxScroll = scrollHandler.getMax();
+        float scrollProgress = maxScroll == 0 ? 0f : (float) (scrollHandler.getValue() / maxScroll);
+        float scrollHeight = Math.max(visibleHeight * (visibleHeight / (float) (visibleHeight + maxScroll)), 28f);
+        scrollHeight = Math.min(visibleHeight, animationScrollHeight.update(scrollHeight));
+
+        float denom = Math.max(1f, visibleHeight - scrollHeight);
+        float scrollY = trackY + denom * scrollProgress;
+        scrollY = MathHelper.clamp(scrollY, trackY, trackY + visibleHeight - scrollHeight);
+
+        ctx.drawRoundedRect(trackX, trackY, scrollbarWidth, visibleHeight,
+                BorderRadius.all(scrollbarWidth / 2f), theme.getForegroundDark().mulAlpha(progress * 0.5f));
+        ctx.drawRoundedRect(trackX, scrollY, scrollbarWidth, scrollHeight,
+                BorderRadius.all(scrollbarWidth / 2f), accent);
+
+        scrollThumbHeight = scrollHeight;
+        scrollThumbY = scrollY;
+
+        List<MenuPopupSetting> remove = new ArrayList<>();
+        for (MenuPopupSetting setting : popupSettings) {
             setting.render(ctx, mouseX, mouseY, progress, theme);
-            if (setting.getAnimationScale().getValue() == 0) {
-                removes.add(setting);
+            if (setting.getAnimationScale().getValue() == 0f) {
+                remove.add(setting);
             }
         }
-        popupSettings.removeAll(removes);
 
-
-        if (animationChangeCategory.getValue() == 0) {
-            selectedCategory = realSelectedCategory;
-        }
-        //ScissorUtility.stopScissor();
+        popupSettings.removeAll(remove);
 
         if (draggingScrollbar) {
-            float scrollbarY = boxY + 22f + 8f + 8f;
-            float newY = (float) mouseY - scrollbarY - scrollClickOffset;
-
-            float scrollRatio = newY / denom;
-            scrollHandler.setTargetValue(-(scrollRatio * scrollHandler.getMax()));
-
+            float newY = (float) mouseY - trackY - scrollClickOffset;
+            float ratio = MathHelper.clamp(newY / denom, 0f, 1f);
+            scrollHandler.setTargetValue(-(ratio * scrollHandler.getMax()));
         }
+
         ctx.popMatrix();
+    }
 
+    private void renderModules(UIContext ctx, float mouseX, float mouseY, float alpha) {
+        List<AbstractMenuElement> visibleModules = modules.stream()
+                .filter(module -> module.getCategory() == selectedCategory)
+                .sorted(Comparator.comparing(AbstractMenuElement::getName, String.CASE_INSENSITIVE_ORDER))
+                .toList();
 
+        int columns = 2;
+        float scrollbarWidth = 6f;
+        float padding = columnSpacing;
+        float availableWidth = contentWidth - scrollbarWidth;
+        float moduleWidth = (availableWidth - padding * (columns - 1)) / columns;
+
+        double[] columnHeights = new double[columns];
+        Font titleFont = Fonts.MEDIUM.getFont(7);
+
+        for (AbstractMenuElement element : visibleModules) {
+            int columnIndex = 0;
+            for (int i = 1; i < columns; i++) {
+                if (columnHeights[i] < columnHeights[columnIndex]) {
+                    columnIndex = i;
+                }
+            }
+
+            float x = contentStartX + columnIndex * (moduleWidth + padding);
+            float y = (float) (contentY + columnHeights[columnIndex] - scrollHandler.getValue());
+
+            element.render(ctx, mouseX, mouseY, titleFont, x, y, moduleWidth, alpha, columnIndex);
+            columnHeights[columnIndex] += element.getHeight() + padding;
+        }
+
+        scrollHandler.update();
+
+        double maxHeight = 0;
+        for (double columnHeight : columnHeights) {
+            if (columnHeight > maxHeight) {
+                maxHeight = columnHeight;
+            }
+        }
+
+        float visibleHeight = visibleContentHeight;
+        float overflow = (float) Math.max(0, maxHeight - visibleHeight);
+        scrollHandler.setMax(overflow);
     }
 
     @Override
     public void onMouseClicked(double mouseX, double mouseY, MouseButton button) {
-
         if (!popupSettings.isEmpty()) {
             for (MenuPopupSetting setting : popupSettings) {
                 if (setting.getBounds().contains(mouseX, mouseY)) {
@@ -278,16 +317,15 @@ public class MenuScreen extends CustomScreen {
                     return;
                 } else {
                     setting.getAnimationScale().update(0);
-
                 }
             }
         }
-        if (isClosing()) return;
+
+        if (isClosing()) {
+            return;
+        }
+
         if (headerPanel.handleMouseClicked(mouseX, mouseY)) {
-            if (headerPanel.searchBarBounds.contains(mouseX, mouseY)) {
-                searchField.setSelected(true);
-                ;
-            }
             return;
         }
 
@@ -295,49 +333,35 @@ public class MenuScreen extends CustomScreen {
             return;
         }
 
-        if (searchField.isSelected()) {
-            searchField.setSelected(false);
+        if (button.getButtonIndex() == GLFW.GLFW_MOUSE_BUTTON_LEFT &&
+                MathUtil.isHovered(mouseX, mouseY, boxX, boxY, boxWidth, headerHeight)) {
+            draggingWindow = true;
+            dragOffsetX = (float) mouseX - boxX;
+            dragOffsetY = (float) mouseY - boxY;
+            return;
         }
-        if (button.getButtonIndex() == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-            if (MathUtil.isHovered(mouseX, mouseY, boxX, boxY, boxWidth, 20)) {
-                dragging = true;
-                dragOffsetX = (float) mouseX - boxX;
-                dragOffsetY = (float) mouseY - boxY;
-                return;
-            }
-        }
-        //чтобы все что обрезанно не нажималось
-        if (!animationClose.isDone()) return;
-        float scrollbarX = boxX + boxWidth - 8 - 2;
-        float scrollbarY = boxY + 22f + 8f + 8f;
-        float visibleHeight = boxHeight - (22f + 8f + 8f);
-        if (button.getButtonIndex() == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-            if (MathUtil.isHovered(mouseX, mouseY, scrollbarX, scrollbarY, 2, visibleHeight)) {
-                draggingScrollbar = true;
 
+        float scrollbarX = contentStartX + contentWidth - 4f;
+        float scrollbarY = contentY;
+        float visibleHeight = visibleContentHeight;
+
+        if (button.getButtonIndex() == GLFW.GLFW_MOUSE_BUTTON_LEFT && visibleHeight > 0) {
+            if (MathUtil.isHovered(mouseX, mouseY, scrollbarX, scrollbarY, 4f, visibleHeight)) {
+                draggingScrollbar = true;
+                scrollClickOffset = MathHelper.clamp((float) mouseY - scrollThumbY, 0f, scrollThumbHeight);
                 return;
             }
         }
+
         if (!MathUtil.isHoveredByCords(mouseX, mouseY, scaledScissorX, scaledScissorY, scaledScissorEndX, scaledScissorEndY)) {
             return;
         }
 
-        this.modules.stream()
-                .filter(m -> searchField.isEmpty() ? m.getCategory() == selectedCategory : m.getName().toLowerCase().contains(searchField.getText().toLowerCase())).forEach(menuModule -> menuModule.onMouseClicked(mouseX, mouseY, button));
-
+        modules.stream()
+                .filter(module -> module.getCategory() == selectedCategory)
+                .forEach(module -> module.onMouseClicked(mouseX, mouseY, button));
 
         super.onMouseClicked(mouseX, mouseY, button);
-    }
-
-    @Override
-    public boolean charTyped(char chr, int modifiers) {
-        if (searchField.isSelected()) {
-            return searchField.charTyped(chr, modifiers);
-        }
-        for (MenuPopupSetting setting : popupSettings) {
-            setting.charTyped(chr, modifiers);
-        }
-        return super.charTyped(chr, modifiers);
     }
 
     @Override
@@ -346,61 +370,25 @@ public class MenuScreen extends CustomScreen {
             setting.onMouseReleased(mouseX, mouseY, button);
         }
 
-
         if (button.getButtonIndex() == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-            dragging = false;
+            draggingWindow = false;
             draggingScrollbar = false;
         }
-        for (AbstractMenuElement module : modules) {
-            module.onMouseReleased(mouseX, mouseY, button);
-        }
+
+        modules.forEach(module -> module.onMouseReleased(mouseX, mouseY, button));
         super.onMouseReleased(mouseX, mouseY, button);
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        boolean returnCheck = false;
-        ;
-        for (MenuPopupSetting setting : popupSettings) {
-            if (setting.keyPressed(keyCode, scanCode, modifiers)) {
-                searchField.setSelected(false);
-                returnCheck = true;
-            }
-            ;
-        }
-        if (returnCheck) {
-            return true;
-        }
-        //чтобы при отмене бинда или закрытия СЕРЧА ГУи -не закрывалась
-        if (searchField.isSelected()) {
-            if (keyCode == GLFW.GLFW_KEY_ESCAPE) {
-                searchField.setSelected(false);
-                return true;
-            }
-            return searchField.keyPressed(keyCode, scanCode, modifiers);
-        }
-        boolean result = false;
-        for (AbstractMenuElement module : modules) {
-            if (module.keyPressed(keyCode, scanCode, modifiers)) {
-                result = true;
-            }
-        }
-        if (result) {
-            return true;
-        }
-        // pfrhsnbt vty.irb
-        if (keyCode == GLFW.GLFW_KEY_ESCAPE && !closing) {
-            onMouseReleased(0, 0, MouseButton.LEFT);
-            onMouseReleased(0, 0, MouseButton.RIGHT);
-            onMouseReleased(0, 0, MouseButton.MIDDLE);
-            for (MenuPopupSetting setting : popupSettings) {
-                setting.getAnimationScale().setTargetValue(0);
-            }
-            closing = true;
+    public void onMouseDragged(double mouseX, double mouseY, MouseButton button, double deltaX, double deltaY) {
+        if (button.getButtonIndex() == GLFW.GLFW_MOUSE_BUTTON_LEFT && draggingWindow) {
+            boxX = (float) mouseX - dragOffsetX;
+            boxY = (float) mouseY - dragOffsetY;
+            return;
         }
 
-
-        return super.keyPressed(keyCode, scanCode, modifiers);
+        modules.forEach(module -> module.onMouseDragged(mouseX, mouseY, button, deltaX, deltaY));
+        super.onMouseDragged(mouseX, mouseY, button, deltaX, deltaY);
     }
 
     @Override
@@ -411,87 +399,53 @@ public class MenuScreen extends CustomScreen {
             }
             return true;
         }
-        float visibleHeight = boxHeight - (22f + 8f + 8f);
 
-        float baseStep = (float) Math.max(20f, Math.min(60f, (scrollHandler.getMax() / visibleHeight) * 10));
-
-
-        scrollHandler.scroll(verticalAmount * baseStep / 8);
+        float visibleHeight = Math.max(visibleContentHeight, 1f);
+        float step = Math.max(24f, Math.min(72f, (scrollHandler.getMax() / visibleHeight) * 12f));
+        scrollHandler.scroll(verticalAmount * step / 8f);
         return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
     }
 
     @Override
-    public void onMouseDragged(double mouseX, double mouseY, MouseButton button, double deltaX, double deltaY) {
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        boolean handled = false;
 
-        if (button.getButtonIndex() == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-            if (dragging) {
-                boxX = (float) mouseX - dragOffsetX;
-                boxY = (float) mouseY - dragOffsetY;
-                return;
+        for (MenuPopupSetting setting : popupSettings) {
+            if (setting.keyPressed(keyCode, scanCode, modifiers)) {
+                handled = true;
             }
-
-
         }
+
+        if (handled) {
+            return true;
+        }
+
         for (AbstractMenuElement module : modules) {
-            module.onMouseDragged(mouseX, mouseY, button, deltaX, deltaY);
+            if (module.keyPressed(keyCode, scanCode, modifiers)) {
+                handled = true;
+            }
         }
 
-        super.onMouseDragged(mouseX, mouseY, button, deltaX, deltaY);
+        if (handled) {
+            return true;
+        }
+
+        if (keyCode == GLFW.GLFW_KEY_ESCAPE && !closing) {
+            onMouseReleased(0, 0, MouseButton.LEFT);
+            onMouseReleased(0, 0, MouseButton.RIGHT);
+            onMouseReleased(0, 0, MouseButton.MIDDLE);
+            for (MenuPopupSetting setting : popupSettings) {
+                setting.getAnimationScale().setTargetValue(0);
+            }
+            closing = true;
+        }
+
+        return super.keyPressed(keyCode, scanCode, modifiers);
     }
 
     @Override
     public void close() {
-        ;
         super.close();
-    }
-
-
-    private void renderModules(UIContext ctx, float mouseX, float mouseY, float alpha, float contentStartX, float contentWidth, float startY) {
-
-        List<AbstractMenuElement> modules = this.modules.stream()
-                .filter(m -> searchField.isEmpty() ? m.getCategory() == selectedCategory : m.getName().toLowerCase().contains(searchField.getText().toLowerCase()))
-                .sorted(Comparator.comparing(menuModule -> menuModule.getName(), String.CASE_INSENSITIVE_ORDER))
-                .toList();
-
-
-        int columns = this.columns;
-        float padding = 6f;
-        float scrollbarWidth = 6f;
-        float maxContentWidth = contentWidth - scrollbarWidth;
-        float moduleWidth = (maxContentWidth - padding * (columns - 1)) / columns;
-
-        Font font = Fonts.MEDIUM.getFont(7);
-        double[] columnHeights = new double[columns];
-
-
-        for (AbstractMenuElement module : modules) {
-            int col = 0;
-            for (int j = 1; j < columns; j++) {
-                if (columnHeights[j] < columnHeights[col]) {
-                    col = j;
-                }
-            }
-
-
-            float x = contentStartX + col * (moduleWidth + padding);
-
-            float y = (float) (startY + columnHeights[col] - scrollHandler.getValue());
-
-
-            module.render(ctx, mouseX, mouseY, font, x, y, moduleWidth, alpha, col);
-
-            columnHeights[col] += module.getHeight() + padding;
-
-        }
-
-        scrollHandler.update();
-        double maxY = Arrays.stream(columnHeights).max().orElse(0);
-
-
-        float visibleHeight = boxHeight - (22f + 8f + 8f);
-
-        scrollHandler.setMax(Math.max(0, maxY - visibleHeight) + (maxY > visibleHeight ? 4 : 0));
-
     }
 
     public void addPopupMenuSetting(MenuPopupSetting setting) {
@@ -504,7 +458,6 @@ public class MenuScreen extends CustomScreen {
 
     @Override
     public void render(UIContext context, float mouseX, float mouseY) {
-
+        // handled by parent layout
     }
-
 }

--- a/src/main/java/zenith/zov/client/screens/menu/panels/HeaderPanel.java
+++ b/src/main/java/zenith/zov/client/screens/menu/panels/HeaderPanel.java
@@ -1,217 +1,85 @@
 package zenith.zov.client.screens.menu.panels;
 
-import net.minecraft.util.math.MathHelper;
-import zenith.zov.Zenith;
-import zenith.zov.base.animations.base.Animation;
-import zenith.zov.base.animations.base.Easing;
 import zenith.zov.base.font.Font;
 import zenith.zov.base.font.Fonts;
 import zenith.zov.base.theme.Theme;
 import zenith.zov.client.modules.api.Category;
-import zenith.zov.utility.render.display.TextBox;
 import zenith.zov.utility.render.display.base.BorderRadius;
-import zenith.zov.utility.render.display.base.CustomSprite;
 import zenith.zov.utility.render.display.base.Rect;
 import zenith.zov.utility.render.display.base.UIContext;
 import zenith.zov.utility.render.display.base.color.ColorRGBA;
 import zenith.zov.utility.render.display.shader.DrawUtil;
-import zenith.zov.client.modules.api.Module;
 
 public class HeaderPanel {
 
-    public Rect themeButtonBounds;
-    public Rect searchBarBounds;
-    public Rect layoutToggleButtonBounds;
-
-    private final TextBox searchField;
-    private final Runnable onLayoutToggle;
     private final Runnable onThemeSwitch;
-    private Category lastCategory = Category.COMBAT;
+    private Rect themeButtonBounds = new Rect(0, 0, 0, 0);
 
-    public HeaderPanel(TextBox searchField, Runnable onLayoutToggle, Runnable onThemeSwitch) {
-        this.searchField = searchField;
-        this.onLayoutToggle = onLayoutToggle;
+    public HeaderPanel(Runnable onThemeSwitch) {
         this.onThemeSwitch = onThemeSwitch;
     }
 
-    Animation animation = new Animation(300, 1, Easing.QUAD_IN_OUT);
+    public void render(UIContext ctx,
+                       float boxX,
+                       float boxY,
+                       float boxWidth,
+                       float headerHeight,
+                       float progress,
+                       Theme theme,
+                       Category category,
+                       ColorRGBA titleColor,
+                       ColorRGBA subtleColor) {
 
-    public void render(UIContext ctx, float contentStartX, float sidebarY,
-                       float boxX, int columns,float boxWidth, float progress,
-                       Theme theme, Category selectedCategory) {
+        float padding = 20f;
+        float dotsY = boxY + padding;
+        float dotsX = boxX + padding;
+        float dotSpacing = 12f;
+        float dotSize = 8f;
 
+        ColorRGBA red = new ColorRGBA(255, 95, 86).mulAlpha(progress);
+        ColorRGBA yellow = new ColorRGBA(255, 189, 46).mulAlpha(progress);
+        ColorRGBA green = new ColorRGBA(39, 201, 63).mulAlpha(progress);
 
-        animation.update(1);
+        ctx.drawRoundedRect(dotsX, dotsY, dotSize, dotSize, BorderRadius.all(dotSize / 2f), red);
+        ctx.drawRoundedRect(dotsX + dotSpacing, dotsY, dotSize, dotSize, BorderRadius.all(dotSize / 2f), yellow);
+        ctx.drawRoundedRect(dotsX + dotSpacing * 2f, dotsY, dotSize, dotSize, BorderRadius.all(dotSize / 2f), green);
 
+        Font titleFont = Fonts.MEDIUM.getFont(9);
+        String title = "Control Center";
+        float titleWidth = titleFont.width(title);
+        float titleX = boxX + (boxWidth - titleWidth) / 2f;
+        float titleY = boxY + padding - 2f;
+        ctx.drawText(titleFont, title, titleX, titleY, titleColor);
 
-        ColorRGBA sideBar = theme.getForegroundColor().mulAlpha(progress);
-        ColorRGBA textColor = theme.getWhite().mulAlpha(progress);
+        Font subtitleFont = Fonts.MEDIUM.getFont(6.5f);
+        String subtitle = category.getName() + " toolkit";
+        float subtitleWidth = subtitleFont.width(subtitle);
+        float subtitleX = boxX + (boxWidth - subtitleWidth) / 2f;
+        float subtitleY = titleY + titleFont.height() + 4f;
+        ctx.drawText(subtitleFont, subtitle, subtitleX, subtitleY, subtleColor);
 
+        float themeSize = 30f;
+        float themeX = boxX + boxWidth - padding - themeSize;
+        float themeY = boxY + padding - 6f;
 
-        float x = contentStartX;
-        x = renderBreadcrumbs(ctx, x, sidebarY, progress, theme, selectedCategory, textColor);
-        x += 8f; // panelGap
-        x = renderStats(ctx, x, sidebarY, progress, theme, selectedCategory, textColor);
-        x += 8f;
-        x = renderThemeButton(ctx, x, sidebarY, progress, theme);
-        x += 8f;
-        renderLayoutButton(ctx, x, sidebarY, progress, theme, columns);
-        renderSearchBar(ctx, boxX, sidebarY, boxWidth, progress, theme);
+        themeButtonBounds = new Rect(themeX, themeY, themeSize, themeSize);
+
+        ColorRGBA buttonBg = theme.getForegroundLight().mulAlpha(progress * 0.6f);
+        ctx.drawRoundedRect(themeX, themeY, themeSize, themeSize, BorderRadius.all(12f), buttonBg);
+        DrawUtil.drawRoundedBorder(ctx.getMatrices(), themeX, themeY, themeSize, themeSize, -0.1f,
+                BorderRadius.all(12f), theme.getForegroundStroke().mulAlpha(progress * 0.6f));
+
+        Font iconFont = Fonts.ICONS.getFont(8);
+        float iconX = themeX + (themeSize - iconFont.width(theme.getIcon())) / 2f;
+        float iconY = themeY + (themeSize - iconFont.height()) / 2f;
+        ctx.drawText(iconFont, theme.getIcon(), iconX, iconY, theme.getColor().mulAlpha(progress));
     }
 
-    private float renderBreadcrumbs(UIContext ctx, float startX, float y,
-                                    float progress, Theme theme,
-                                    Category selectedCategory,
-                                    ColorRGBA textColor) {
-        String name = selectedCategory.getName();
-        Font font = Fonts.MEDIUM.getFont(7);
-        Font icon7 = Fonts.ICONS.getFont(7);
-        Font icon6 = Fonts.ICONS.getFont(5);
-
-        float homeIcon = 7, arrowIcon = 6, catIcon = 7;
-        float pad = 8, gap = 4, tgap = 2;
-        float textW = MathHelper.lerp(animation.getValue(), font.width(lastCategory.getName()), font.width(name));
-        float width = pad * 2 + homeIcon + gap + arrowIcon  + catIcon + tgap + textW;
-        float h = 22;
-
-        ColorRGBA bar = theme.getForegroundColor().mulAlpha(progress);
-        ctx.drawRoundedRect(startX, y, width, h, BorderRadius.all(7), bar);
-        DrawUtil.drawRoundedBorder(ctx.getMatrices(), startX, y, width, h, -0.1f,
-                BorderRadius.all(7), theme.getForegroundStroke().mulAlpha(progress));
-
-
-        float cx = startX + pad;
-        float vy = y + h / 2f;
-        ctx.drawText(icon7, "7", cx, vy - icon7.height() / 2 - .5f, theme.getColor().mulAlpha(progress));
-        cx += icon7.width("7") + gap;
-        ctx.drawText(icon6, "A", cx + 1, vy - icon6.height() / 2 - .3f, theme.getForegroundGray().mulAlpha(progress));
-        cx += icon6.width("A") + gap;
-        ctx.enableScissor((int) startX+20, (int) y, (int) (startX + width), (int) (y + h));
-
-        float offset = (1-animation.getValue())*font.width(name)*2;
-        float offset2 = (animation.getValue())*font.width(lastCategory.getName());
-
-        ctx.drawText(font, name, cx+offset, vy - font.height() / 2f, textColor.mulAlpha(animation.getValue()));
-        ctx.drawText(font, lastCategory.getName(), cx-offset2, vy - font.height() / 2f, textColor.mulAlpha(1-animation.getValue()));
-        ctx.disableScissor();
-        return startX + width;
-    }
-
-    private float renderStats(UIContext ctx, float startX, float y,
-                              float progress, Theme theme,
-                              Category cat, ColorRGBA textColor) {
-        int enabled = 0, total = 0;
-        for (Module m : Zenith.getInstance().getModuleManager().getModules()) {
-            if (m.getCategory() == cat) {
-                total++;
-                if (m.isEnabled()) enabled++;
-            }
-        }
-        Font font = Fonts.MEDIUM.getFont(7);
-        Font iconFont = Fonts.ICONS.getFont(7);
-        float w = 8 +iconFont.width(cat.getIcon()) + 4 +font.width(String.valueOf(enabled))+ 1 + 8+1 + iconFont.width(cat.getIcon()) + 4 +font.width(String.valueOf(total))+8 ;
-        float h = 22;
-        ColorRGBA bar = theme.getForegroundColor().mulAlpha(progress);
-        ctx.drawRoundedRect(startX, y, w, h, BorderRadius.all(7), bar);
-        DrawUtil.drawRoundedBorder(ctx.getMatrices(), startX, y, w, h, -0.1f,
-                BorderRadius.all(7), theme.getForegroundStroke().mulAlpha(progress));
-
-
-        float iconSz = 7;
-        float cx = startX + 8;
-        float ty = y + (h - font.height()) / 2f;
-        float iy = y + (h - iconFont.height()) / 2f -0.5f;
-
-        ctx.drawText(iconFont,cat.getIcon(),cx+(cat.getIcon().equals("2")?1:0),iy,theme.getColor().mulAlpha(progress));
-        cx += iconFont.width(cat.getIcon()) + 4;
-        ctx.drawText(font, String.valueOf(enabled), cx, ty, textColor);
-        cx += font.width(String.valueOf(enabled)) ;
-        cx+=1f;
-        ctx.drawSprite(new CustomSprite("icons/separator.png"), cx, iy-1, 8, 8,
-                ColorRGBA.WHITE.mulAlpha(progress));
-        cx += 8+1 ;
-        ctx.drawText(iconFont,cat.getIcon(),cx,iy,theme.getColor().mulAlpha(progress));
-        cx +=iconFont.width(cat.getIcon())+4;
-
-        ctx.drawText(font, String.valueOf(total), cx, ty, textColor);
-
-        return startX + w;
-    }
-
-    private float renderThemeButton(UIContext ctx, float startX, float y,
-                                    float progress, Theme theme) {
-        float size = 22;
-        this.themeButtonBounds = new Rect(startX, y, size, size);
-        drawIconButton(ctx, startX, y, size, theme.getIcon(), progress, theme);
-        return startX + size;
-    }
-
-    private float renderLayoutButton(UIContext ctx, float startX, float y,
-                                     float progress, Theme theme, int cols) {
-        float size = 22;
-        this.layoutToggleButtonBounds = new Rect(startX, y, size, size);
-        String icon = cols == 2 ? ":" : cols == 3 ? ";" : "9";
-        drawIconButton(ctx, startX, y, size, icon, progress, theme);
-        return startX + size;
-    }
-
-    private void drawIconButton(UIContext ctx, float x, float y,
-                                float s, String icon,
-                                float progress, Theme theme) {
-        ColorRGBA bar = theme.getForegroundColor().mulAlpha(progress);
-        ctx.drawRoundedRect(x, y, s, s, BorderRadius.all(6), bar);
-        DrawUtil.drawRoundedBorder(ctx.getMatrices(), x, y, s, s, -0.1f,
-                BorderRadius.all(6), theme.getForegroundStroke().mulAlpha(progress));
-        Font iconF = Fonts.ICONS.getFont(7);
-        float ix = x + (s - iconF.width(icon)) / 2f;
-        float iy = y + (s - iconF.height()) / 2f;
-        ctx.drawText(iconF, icon, ix, iy, theme.getColor().mulAlpha(progress));
-    }
-
-    private void renderSearchBar(UIContext ctx, float boxX, float y,
-                                 float boxWidth, float progress, Theme theme) {
-
-        float w = 128, h = 22, pad = 8;
-        float x = boxX + boxWidth - pad - w;
-        this.searchBarBounds = new Rect(x, y, w, h);
-
-        ColorRGBA bar = theme.getForegroundColor().mulAlpha(progress);
-        ctx.drawRoundedRect(x, y, w, h, BorderRadius.all(6), bar);
-        DrawUtil.drawRoundedBorder(ctx.getMatrices(), x, y, w, h, -0.1f,
-                BorderRadius.all(6), theme.getForegroundStroke().mulAlpha(progress));
-
-        Font font = Fonts.MEDIUM.getFont(7);
-        String txt = searchField.getText();
-        boolean empty = txt.isEmpty() && !searchField.isSelected();
-        float ty = y + (h - font.height()) / 2f;
-        if (empty) {
-            ctx.drawText(font, "Search", x + 8, ty, theme.getWhite().mulAlpha(progress * 0.5f));
-        } else {
-            //ctx.drawText(font, txt, x + 8, ty, theme.getWhite().mulAlpha(progress));
-            ctx.enableScissor((int) x+8,(int) ty-10,(int)Math.ceil( x+8+128),(int) Math.ceil(ty)+10);
-            searchField.render(ctx,x+8,ty,theme.getWhite().mulAlpha(progress),theme.getWhite().mulAlpha(progress * 0.5f));
-//            if (searchField.isSelected() && (System.currentTimeMillis() / 500) % 2 == 0) {
-//                float tw = font.width(txt);
-//                ctx.drawRect(x + 8 + tw, y + 4, 1, h - 8, theme.getWhite().mulAlpha(progress));
-//            }
-            ctx.disableScissor();
-        }
-    }
-    public void resetAnim(Category last,Category next) {
-
-            animation.reset(0);
-
-        this.lastCategory = last;
-    }
     public boolean handleMouseClicked(double mouseX, double mouseY) {
-        if (layoutToggleButtonBounds.contains(mouseX, mouseY)) {
-            onLayoutToggle.run();
-            return true;
-        }
         if (themeButtonBounds.contains(mouseX, mouseY)) {
             onThemeSwitch.run();
             return true;
         }
-        return searchBarBounds.contains(mouseX, mouseY);
+        return false;
     }
 }

--- a/src/main/java/zenith/zov/client/screens/menu/panels/SideBarCategory.java
+++ b/src/main/java/zenith/zov/client/screens/menu/panels/SideBarCategory.java
@@ -1,43 +1,40 @@
 package zenith.zov.client.screens.menu.panels;
 
 import lombok.Getter;
-import net.minecraft.util.math.MathHelper;
 import zenith.zov.base.animations.base.Animation;
 import zenith.zov.base.animations.base.Easing;
 import zenith.zov.base.font.Font;
 import zenith.zov.base.font.Fonts;
 import zenith.zov.client.modules.api.Category;
+import zenith.zov.utility.render.display.base.Rect;
 import zenith.zov.utility.render.display.base.UIContext;
 import zenith.zov.utility.render.display.base.color.ColorRGBA;
 
 public class SideBarCategory {
+
     @Getter
     private final Category category;
-    private final Animation animationSwitch;
+    private final Animation selectionAnimation;
 
     public SideBarCategory(Category category) {
         this.category = category;
-        animationSwitch = new Animation(200, category == Category.COMBAT ? 1 : 0, Easing.LINEAR);
+        this.selectionAnimation = new Animation(180, category == Category.COMBAT ? 1f : 0f, Easing.QUAD_IN_OUT);
     }
 
-    public void render(UIContext ctx, float x, float y, float width, float height, float sidebarProgress, boolean selected, ColorRGBA textColor,ColorRGBA textColorDisable, ColorRGBA iconColorDisable, ColorRGBA primary) {
-        animationSwitch.animateTo(selected ? 1 : 0);
-        animationSwitch.update();
-        ColorRGBA mixColor = iconColorDisable.mix(primary, animationSwitch.getValue());
-        ColorRGBA mixColorText = textColorDisable.mix(textColor, animationSwitch.getValue());
-        Font font = Fonts.ICONS.getFont(7);
+    public void render(UIContext ctx,
+                       Rect bounds,
+                       boolean selected,
+                       ColorRGBA activeColor,
+                       ColorRGBA inactiveColor) {
+        selectionAnimation.animateTo(selected ? 1f : 0f);
+        float blend = selectionAnimation.update();
 
-        float offestY = (height - font.height()) / 2;
-        float scale = MathHelper.lerp(sidebarProgress,1f,0.8f);
-        float iconWidth = font.width(category.getIcon());
-        ctx.pushMatrix();
-        ctx.getMatrices().translate(x + 8 + iconWidth/2 +(category==Category.PLAYER?1:0), y + offestY+font.height()/2,0);
-        ctx.getMatrices().scale(scale,scale,1);
-        ctx.getMatrices().translate(-(x + 8 + iconWidth/2), -(y + offestY+font.height()/2),0);
-        ctx.drawText(Fonts.ICONS.getFont(7), category.getIcon(), x + 8, y + offestY, mixColor);
-        ctx.popMatrix();
-        Font categoryFont = Fonts.MEDIUM.getFont(7);
-        ctx.drawText(categoryFont,category.getName(),x + 8+iconWidth*scale+6,y+(height-font.height())/2,mixColorText);
+        Font font = Fonts.MEDIUM.getFont(6.5f);
+        String label = category.getName();
+        float textX = bounds.x() + (bounds.width() - font.width(label)) / 2f;
+        float textY = bounds.y() + (bounds.height() - font.height()) / 2f;
+
+        ColorRGBA color = inactiveColor.mix(activeColor, blend);
+        ctx.drawText(font, label, textX, textY, color);
     }
-
 }


### PR DESCRIPTION
## Summary
- redesign the click GUI into a centered card layout with hero header, segmented navigation, and refreshed scroll handling
- simplify the header panel to window controls plus a theme toggle while animating the category navigation chips
- restyle module cards with animated switches, keybind pills, and spacious setting sections that mirror the new concept art

## Testing
- ./gradlew build *(fails: existing TargetHudComponent compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d125186b408323add53d0374d0bc6c